### PR TITLE
fix-new-stream-created

### DIFF
--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -1,4 +1,3 @@
-
 import 'startwith_stream_transformer.dart';
 
 class Snapshot {
@@ -7,10 +6,15 @@ class Snapshot {
   final String document;
   dynamic value = double.infinity;
 
-  Stream get stream => _streamInit.map((v) {
-    value = v;
-    return v;
-  }).transform(StartWithStreamTransformer(value)).where((v) => v != double.infinity);
+  Stream stream;
 
-  Snapshot(this.document, this._streamInit, this.close);
+  Snapshot(this.document, this._streamInit, this.close) {
+    stream = _streamInit
+        .map((v) {
+          value = v;
+          return v;
+        })
+        .transform(StartWithStreamTransformer(value))
+        .where((v) => v != double.infinity);
+  }
 }


### PR DESCRIPTION
Com um getter retornando a stream transformada, cada chamada do getter retorna uma nova stream (diferente da anterior, por ser transformada), isso poderia causar bugs no StreamBuilder (Flutter), por exemplo, onde o mesmo compara de o objeto de stream antigo é igual ao atual.