### PR TITLE
fix cached query broadcast stream exception

### DIFF
--- a/lib/src/core/hasura_connect_base.dart
+++ b/lib/src/core/hasura_connect_base.dart
@@ -78,7 +78,7 @@ class HasuraConnectBase implements HasuraConnect {
   }
 
   Stream _generateFutureQueryStream(Future query) {
-    return Stream.fromFuture(query);
+    return Stream.fromFuture(query).asBroadcastStream();
   }
 
   @override


### PR DESCRIPTION
Existe um erro que acontece ao tentar criar uma cachedQuery, esse erro ocorre porque ao criar uma Stream.fromFuture, é criada uma stream de subscrição única, ao invés de uma stream de broadcast, esse pull request vai consertar isso.