### PR TITLE
fix add header error, enhance error handling and protect header

### DIFF
--- a/lib/src/core/hasura.dart
+++ b/lib/src/core/hasura.dart
@@ -15,6 +15,10 @@ abstract class HasuraConnect {
       token: token,
     );
   }
+  
+  bool get isConnected;
+
+  Map<String,String> get headers;
 
   ///change function listener for token
   void changeToken(Future<String> Function(bool isError) token);


### PR DESCRIPTION
Esse fork contém o fix dos seguintes problemas:
#28 
#26
#25 
#17 
alterações:
agora é fornecido um header "padrão" caso o usuário não especifique um
o getter para os headers é fornecido com um Map imutável (adições / deleções) só podem ser feitas utilizando addHeader ou removeHeader
expõe um booleano para mostrar se a conexão está ativa.
resolvido:
erro ao adicionar um header pelos métodos addHeader sem antes adicionar via construtor
tratamento de erros levemente melhorado, agora caso ocorra uma socket exception (excepção sobre problemas de conexão)
agora propaga quaisquer erros que acontecerem dentro de mutações