### PR TITLE
Fix typo on instance variable inside _copyWith().

### DIFF
--- a/lib/src/snapshot/snapshot_data.dart
+++ b/lib/src/snapshot/snapshot_data.dart
@@ -69,7 +69,7 @@ class SnapshotData<T> extends Snapshot<T> {
     return SnapshotData<S>(
       info ?? this.info,
       streamInit ?? _streamInit,
-      close ?? close,
+      close ?? _close,
       renew ?? _renew,
       conn: conn ?? _conn,
       hydrated: hydrated ?? _hydrated,


### PR DESCRIPTION
Causes a call() on null exception when calling snapshot.close() on a subscription that has been converted using convert().
hasuraConnect.subscription(subDoc).convert(...