### PR TITLE
If supplying a HttpClient to HasuraConnect, it will be closed & unusable after one query/mutation.

### DIFF
--- a/lib/src/presenter/hasura_connect_base.dart
+++ b/lib/src/presenter/hasura_connect_base.dart
@@ -53,9 +53,9 @@ class HasuraConnect {
     this.reconnectionAttemp,
     List<Interceptor> interceptors,
     this.headers,
-    http.Client httpClient,
+    Function() httpClientFactory
   }) {
-    startModule(httpClient == null ? null : () => httpClient);
+    startModule(httpClientFactory);
     _interceptorExecutor = InterceptorExecutor(interceptors);
 
     _subscription = controller.stream


### PR DESCRIPTION
The httpClient, if provided as an instance, will be used once and closed by PostHttpRequest.post() in /lib/src/external/post_http_request.dart.
That httpClient cannot be used again.
Any additional query/mutation calls will throw an error when attempting requests
on this closed httpClient (i.e. tried to call openUrl on null).
The current startModule call, won't instantiate a new HttpClient instance,
rather it will reuse the closed original instance.

By providing a factory function, startModule will successfully create new
httpClients for each PostHttpRequest.post().

This was difficult to find because if you are also using a subscription
with an open/live httpClient, (which doesn't get closed), then this error will not
occur (I'm not exactly clear why, perhaps the subscription's httpClient/connection
gets used by query/mutation calls and won't be closed?).

USAGE...

OLD
`HasuraConnect(graphQLUrl, httpClient: http.Client());`

NEW
`HasuraConnect(graphQLUrl, httpClientFactory: () => http.Client())`

Note: in the OLD example, `http.Client()` gets evaluated into an instance prior to being supplied as the argument for `httpClient`, so it won't be usable as a factory in the future. 
So the old startModule call: 
`startModule(httpClient == null ? null : () => httpClient);`
... won't create a new instance, it just wraps the originally supplied client instance in an anonymous closure.
